### PR TITLE
chore: narrow published prisma files to models directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "dist",
     "!dist/generated",
     "README.md",
-    "prisma",
+    "prisma/models",
     "prisma.config.ts"
   ],
   "scripts": {


### PR DESCRIPTION
## Summary
- Only include `prisma/models` in the npm package instead of the entire `prisma` directory
- Avoids publishing migrations and config files to npm

## Test plan
- [ ] Verify `npm pack --dry-run` only includes prisma/models