### PR TITLE
refactor: extract setFileHeaders to shared utility module

### DIFF
--- a/src/routes/crate.ts
+++ b/src/routes/crate.ts
@@ -1,9 +1,10 @@
 import { createReadStream } from 'node:fs';
-import type { FastifyPluginAsync, FastifyReply } from 'fastify';
+import type { FastifyPluginAsync } from 'fastify';
 import type { ZodTypeProvider } from 'fastify-type-provider-zod';
 import { z } from 'zod/v4';
 import type { FileMetadata, RoCrateHandler } from '../types/fileHandlers.js';
 import { createInternalError, createNotFoundError } from '../utils/errors.js';
+import { setFileHeaders } from '../utils/headers.js';
 
 const paramsSchema = z.object({
   id: z.url(),
@@ -11,21 +12,6 @@ const paramsSchema = z.object({
 
 type CrateRouteOptions = {
   roCrateHandler: RoCrateHandler;
-};
-
-const setFileHeaders = (
-  reply: FastifyReply,
-  metadata: { contentType: string; contentLength: number; etag?: string; lastModified?: Date },
-) => {
-  reply.header('Content-Type', metadata.contentType);
-  reply.header('Content-Length', metadata.contentLength.toString());
-
-  if (metadata.etag) {
-    reply.header('ETag', metadata.etag);
-  }
-  if (metadata.lastModified) {
-    reply.header('Last-Modified', metadata.lastModified.toUTCString());
-  }
 };
 
 const crate: FastifyPluginAsync<CrateRouteOptions> = async (fastify, opts) => {

--- a/src/routes/file.ts
+++ b/src/routes/file.ts
@@ -1,9 +1,10 @@
 import { createReadStream } from 'node:fs';
-import type { FastifyPluginAsync, FastifyReply } from 'fastify';
+import type { FastifyPluginAsync } from 'fastify';
 import type { ZodTypeProvider } from 'fastify-type-provider-zod';
 import { z } from 'zod/v4';
 import type { FileHandler, FileMetadata } from '../types/fileHandlers.js';
 import { createInternalError, createNotFoundError } from '../utils/errors.js';
+import { setFileHeaders } from '../utils/headers.js';
 
 const paramsSchema = z.object({
   id: z.url(),
@@ -17,21 +18,6 @@ const querySchema = z.object({
 
 type FileRouteOptions = {
   fileHandler: FileHandler;
-};
-
-const setFileHeaders = (
-  reply: FastifyReply,
-  metadata: { contentType: string; contentLength: number; etag?: string; lastModified?: Date },
-) => {
-  reply.header('Content-Type', metadata.contentType);
-  reply.header('Content-Length', metadata.contentLength.toString());
-
-  if (metadata.etag) {
-    reply.header('ETag', metadata.etag);
-  }
-  if (metadata.lastModified) {
-    reply.header('Last-Modified', metadata.lastModified.toUTCString());
-  }
 };
 
 const file: FastifyPluginAsync<FileRouteOptions> = async (fastify, opts) => {

--- a/src/utils/headers.ts
+++ b/src/utils/headers.ts
@@ -1,0 +1,16 @@
+import type { FastifyReply } from 'fastify';
+
+export const setFileHeaders = (
+  reply: FastifyReply,
+  metadata: { contentType: string; contentLength: number; etag?: string; lastModified?: Date },
+) => {
+  reply.header('Content-Type', metadata.contentType);
+  reply.header('Content-Length', metadata.contentLength.toString());
+
+  if (metadata.etag) {
+    reply.header('ETag', metadata.etag);
+  }
+  if (metadata.lastModified) {
+    reply.header('Last-Modified', metadata.lastModified.toUTCString());
+  }
+};


### PR DESCRIPTION
## Summary
- Extract the duplicated `setFileHeaders` function from `crate.ts` and `file.ts` into `src/utils/headers.ts`
- No behaviour change

## Test plan
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes