### PR TITLE
refactor: improve validation error structure

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -61,7 +61,12 @@ const setupValidation = (fastify: FastifyInstance) => {
 
   fastify.setErrorHandler((error, _req, reply) => {
     if (hasZodFastifySchemaValidationErrors(error)) {
-      return reply.code(400).send(createValidationError('The request parameters are invalid', error.validation));
+      const violations = error.validation.map((v) => ({
+        field: v.instancePath,
+        message: v.message,
+      }));
+
+      return reply.code(400).send(createValidationError('The request parameters are invalid', violations));
     }
 
     // NOTE: We are exposing the error message here for development purposes.

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -29,16 +29,17 @@ const createErrorResponse = (code: ErrorCode, message: string, details?: ErrorDe
   },
 });
 
-export const createValidationError = (message: string, issues: string[]): StandardErrorResponse =>
-  createErrorResponse(ERROR_CODES.VALIDATION_ERROR, message, { issues });
+type ValidationViolation = {
+  field: string;
+  message: string;
+  value?: unknown;
+};
+
+export const createValidationError = (message: string, violations: ValidationViolation[]): StandardErrorResponse =>
+  createErrorResponse(ERROR_CODES.VALIDATION_ERROR, message, { violations });
 
 export const createNotFoundError = (message: string, entityId?: string): StandardErrorResponse =>
   createErrorResponse(ERROR_CODES.NOT_FOUND, message, entityId ? { entityId } : undefined);
-
-// export const createRateLimitError = (retryAfter: number): StandardErrorResponse =>
-//   createErrorResponse(ERROR_CODES.RATE_LIMIT_EXCEEDED, 'Rate limit exceeded. Please retry after the specified time.', {
-//     retryAfter,
-//   });
 
 export const createInternalError = (message = 'Internal server error'): StandardErrorResponse => {
   return createErrorResponse(ERROR_CODES.INTERNAL_ERROR, message);


### PR DESCRIPTION
## Summary
- Change `createValidationError` to accept structured violations (`{ field, message }`) instead of plain strings
- Map Zod validation errors to structured format in the error handler
- Remove commented-out rate limit error

## Test plan
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes
- [ ] Validation errors now return `{ violations: [{ field, message }] }` in details