### PR TITLE
feat: make geohashPrecision optional in search

### DIFF
--- a/src/routes/search.ts
+++ b/src/routes/search.ts
@@ -24,7 +24,7 @@ const searchParamsSchema = z.object({
   query: z.string(),
   filters: z.record(z.string(), z.array(z.string())).optional(),
   boundingBox: boundingBoxSchema.optional(),
-  geohashPrecision: z.number().int().min(0).max(12).default(5),
+  geohashPrecision: z.number().int().min(1).max(12).optional(),
   limit: z.number().int().min(1).max(1000).default(100),
   offset: z.number().int().min(0).default(0),
   sort: z.enum(['id', 'name', 'createdAt', 'updatedAt', 'relevance']).default('relevance'),

--- a/src/utils/queryBuilder.ts
+++ b/src/utils/queryBuilder.ts
@@ -92,7 +92,7 @@ export class OpensearchQueryBuilder {
     };
   }
 
-  buildAggregations(geohashPrecision: number, boundingBox?: BoundingBox) {
+  buildAggregations(geohashPrecision?: number, boundingBox?: BoundingBox) {
     const aggs = { ...this.aggregations };
 
     // Add geohash aggregation if precision is specified


### PR DESCRIPTION
## Summary
- Allow search requests to omit `geohashPrecision` instead of requiring it with a default
- Geohash aggregation is only built when both precision and bounding box are provided

## Test plan
- [ ] `pnpm lint` passes
- [ ] `pnpm test` passes
- [ ] Search requests without `geohashPrecision` no longer fail validation