### PR TITLE
fix!: rename database tables to lowercase

### DIFF
--- a/prisma/migrations/20260326000000_lowercase_table_names/migration.sql
+++ b/prisma/migrations/20260326000000_lowercase_table_names/migration.sql
@@ -1,0 +1,5 @@
+-- RenameTable
+RENAME TABLE `Entity` TO `entity`;
+
+-- RenameTable
+RENAME TABLE `File` TO `file`;

--- a/prisma/models/entity.prisma
+++ b/prisma/models/entity.prisma
@@ -17,4 +17,6 @@ model Entity {
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+
+  @@map("entity")
 }

--- a/prisma/models/file.prisma
+++ b/prisma/models/file.prisma
@@ -17,4 +17,5 @@ model File {
   updatedAt         DateTime @updatedAt
 
   @@unique([fileId])
+  @@map("file")
 }


### PR DESCRIPTION
## Summary
- Add `@@map` directives to Entity and File models so Prisma maps them to lowercase table names (`entity`, `file`)
- Aligns with common MySQL conventions

**BREAKING CHANGE:** Existing databases must run the migration to rename tables from `Entity`/`File` to `entity`/`file`.

## Test plan
- [ ] `pnpm lint` passes
- [ ] Migration applies cleanly to existing database