### PR TITLE
fix(files): filter by entity.memberOf instead of entity.id

### DIFF
--- a/src/routes/files.test.ts
+++ b/src/routes/files.test.ts
@@ -70,11 +70,16 @@ describe('Files Route', () => {
       });
 
       expect(response.statusCode).toBe(200);
-      const body = JSON.parse(response.body) as { total: number };
+      const body = JSON.parse(response.body) as { total: number; files: unknown[] };
       expect(body.total).toBe(1);
+      expect(body.files).toHaveLength(1);
+      expect(body.files[0]).toMatchObject({
+        id: 'http://example.com/file1.wav',
+        filename: 'file1.wav',
+      });
       expect(prisma.file.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
-          where: { entity: { id: 'http://example.com/collection/1' } },
+          where: { entity: { memberOf: 'http://example.com/collection/1' } },
         }),
       );
     });

--- a/src/routes/files.ts
+++ b/src/routes/files.ts
@@ -37,7 +37,7 @@ const files: FastifyPluginAsync<FilesRouteOptions> = async (fastify, opts) => {
         const where: NonNullable<Parameters<typeof prisma.file.findMany>[0]>['where'] = {};
 
         if (memberOf) {
-          where.entity = { id: memberOf };
+          where.entity = { memberOf };
         }
 
         const [dbFiles, total] = await Promise.all([

--- a/src/test/integration.setup.ts
+++ b/src/test/integration.setup.ts
@@ -149,6 +149,31 @@ export async function seedTestData() {
     data: testEntities,
   });
 
+  const testFiles = [
+    {
+      id: 'http://example.com/entity/4',
+      filename: 'test-audio.wav',
+      mediaType: 'audio/wav',
+      size: BigInt(2048),
+      meta: {},
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    {
+      id: 'http://example.com/entity/5',
+      filename: 'collection-metadata.csv',
+      mediaType: 'text/csv',
+      size: BigInt(512),
+      meta: {},
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+  ];
+
+  await prisma.file.createMany({
+    data: testFiles,
+  });
+
   await opensearch.indices.create({
     index: 'entities',
     body: {

--- a/src/test/integration.test.ts
+++ b/src/test/integration.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
-import type { AuthorisedEntity } from '../transformers/default.js';
+import type { AuthorisedEntity, AuthorisedFile } from '../transformers/default.js';
 import type { StandardErrorResponse } from '../utils/errors.js';
 import {
   cleanupTestData,
@@ -232,6 +232,77 @@ describe('Integration Tests', () => {
       expect(body.entities[0].name).toBe('test-audio.wav');
       expect(body.entities[1].name).toBe('Test Person');
       expect(body.entities[2].name).toBe('Test Object');
+    });
+  });
+
+  describe('GET /files', () => {
+    it('should return all files', async () => {
+      const app = getTestApp();
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/files',
+      });
+      const body = JSON.parse(response.body) as { total: number; files: AuthorisedFile[] };
+
+      expect(response.statusCode).toBe(200);
+      expect(body.total).toBe(2);
+      expect(body.files).toHaveLength(2);
+    });
+
+    it('should filter files by memberOf (Object parent)', async () => {
+      const app = getTestApp();
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/files',
+        query: {
+          memberOf: 'http://example.com/entity/2',
+        },
+      });
+      const body = JSON.parse(response.body) as { total: number; files: AuthorisedFile[] };
+
+      expect(response.statusCode).toBe(200);
+      expect(body.total).toBe(1);
+      expect(body.files).toHaveLength(1);
+      expect(body.files[0].id).toBe('http://example.com/entity/4');
+      expect(body.files[0].filename).toBe('test-audio.wav');
+    });
+
+    it('should filter files by memberOf (Collection parent)', async () => {
+      const app = getTestApp();
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/files',
+        query: {
+          memberOf: 'http://example.com/entity/1',
+        },
+      });
+      const body = JSON.parse(response.body) as { total: number; files: AuthorisedFile[] };
+
+      expect(response.statusCode).toBe(200);
+      expect(body.total).toBe(1);
+      expect(body.files).toHaveLength(1);
+      expect(body.files[0].id).toBe('http://example.com/entity/5');
+      expect(body.files[0].filename).toBe('collection-metadata.csv');
+    });
+
+    it('should return empty list when memberOf matches no entity', async () => {
+      const app = getTestApp();
+
+      const response = await app.inject({
+        method: 'GET',
+        url: '/files',
+        query: {
+          memberOf: 'http://example.com/entity/does-not-exist',
+        },
+      });
+      const body = JSON.parse(response.body) as { total: number; files: AuthorisedFile[] };
+
+      expect(response.statusCode).toBe(200);
+      expect(body.total).toBe(0);
+      expect(body.files).toHaveLength(0);
     });
   });
 


### PR DESCRIPTION
## Summary

- `GET /files?memberOf=X` was filtering files whose related entity *id* equalled the given URL, instead of files whose entity is a *member of* that collection. Because `File` and `Entity` share an id (1:1 relation via `File.id` → `Entity.id`), this collapsed to a primary-key lookup that almost never matched a collection URL.
- The unit test in `files.test.ts` reinforced the bug — it asserted `prisma.file.findMany` was called with the wrong `where` shape, which mocks happily accept. The fix updates that assertion *and* adds a response-body assertion.
- Adds `/files` integration coverage backed by real File rows seeded against the test DB. Verified the new integration tests fail when the bug is reintroduced.

## Test plan
- [x] `pnpm test src/routes/files.test.ts` — 12 passed
- [x] `pnpm test src/test/integration.test.ts` — 25 passed (4 new `/files` tests)
- [x] `pnpm exec tsc --noEmit` — clean
- [x] Reverted the route fix locally and confirmed both new integration filter tests fail