### PR TITLE
fix: add type ReadableStream to supported file stream

### DIFF
--- a/src/types/fileHandlers.ts
+++ b/src/types/fileHandlers.ts
@@ -21,7 +21,7 @@ export type FileRedirectResult = {
 
 export type FileStreamResult = {
   type: 'stream';
-  stream: Readable;
+  stream: Readable | ReadableStream;
   metadata: FileMetadata;
 };
 


### PR DESCRIPTION
Fastify already support sending the ReadableStream (from the standard Web Streams API) as response. This fix just added the type to the FileStreamResult.