### PR TITLE
Feat/restrict metadata

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -132,8 +132,8 @@ const app: FastifyPluginAsync<Options> = async (fastify, options) => {
   fastify.register(entities, { prisma, accessTransformer, entityTransformers });
   fastify.register(entity, { prisma, accessTransformer, entityTransformers });
   fastify.register(files, { prisma, fileAccessTransformer, fileTransformers });
-  fastify.register(file, { prisma, fileHandler });
-  fastify.register(crate, { prisma, roCrateHandler });
+  fastify.register(file, { prisma, fileAccessTransformer, fileHandler });
+  fastify.register(crate, { prisma, accessTransformer, roCrateHandler });
   fastify.register(search, {
     prisma,
     opensearch,

--- a/src/app.ts
+++ b/src/app.ts
@@ -134,7 +134,7 @@ const app: FastifyPluginAsync<Options> = async (fastify, options) => {
 
   fastify.register(entities, { prisma, accessTransformer, entityTransformers, resolveValidLicenses });
   fastify.register(entity, { prisma, accessTransformer, entityTransformers });
-  fastify.register(files, { prisma, fileAccessTransformer, fileTransformers });
+  fastify.register(files, { prisma, fileAccessTransformer, fileTransformers, resolveValidLicenses });
   fastify.register(file, { prisma, fileAccessTransformer, fileHandler });
   fastify.register(crate, { prisma, accessTransformer, roCrateHandler });
   fastify.register(search, {

--- a/src/app.ts
+++ b/src/app.ts
@@ -16,6 +16,7 @@ import type {
   EntityTransformer,
   FileAccessTransformer,
   FileTransformer,
+  TransformerContext,
 } from './types/transformers.js';
 import { createValidationError } from './utils/errors.js';
 import type { QueryBuilderOptions } from './utils/queryBuilder.js';
@@ -83,6 +84,7 @@ export type Options = {
   fileTransformers?: FileTransformer[];
   fileHandler: FileHandler;
   roCrateHandler: RoCrateHandler;
+  resolveValidLicenses?: (opt: TransformerContext) => Promise<string[]>;
 };
 const app: FastifyPluginAsync<Options> = async (fastify, options) => {
   const {
@@ -97,6 +99,7 @@ const app: FastifyPluginAsync<Options> = async (fastify, options) => {
     fileTransformers,
     fileHandler,
     roCrateHandler,
+    resolveValidLicenses,
   } = options;
 
   if (!prisma) {
@@ -129,7 +132,7 @@ const app: FastifyPluginAsync<Options> = async (fastify, options) => {
   }
   setupValidation(fastify);
 
-  fastify.register(entities, { prisma, accessTransformer, entityTransformers });
+  fastify.register(entities, { prisma, accessTransformer, entityTransformers, resolveValidLicenses });
   fastify.register(entity, { prisma, accessTransformer, entityTransformers });
   fastify.register(files, { prisma, fileAccessTransformer, fileTransformers });
   fastify.register(file, { prisma, fileAccessTransformer, fileHandler });
@@ -138,6 +141,7 @@ const app: FastifyPluginAsync<Options> = async (fastify, options) => {
     prisma,
     opensearch,
     accessTransformer,
+    resolveValidLicenses,
     entityTransformers,
     queryBuilderClass,
     queryBuilderOptions,

--- a/src/routes/__snapshots__/entity.test.ts.snap
+++ b/src/routes/__snapshots__/entity.test.ts.snap
@@ -72,3 +72,15 @@ exports[`Entity Route > GET /entity/:id > should return null for memberOf/rootCo
   "rootCollection": null,
 }
 `;
+
+exports[`Entity Route Restricted > GET /entity/:id > should return 403 1`] = `
+{
+  "error": {
+    "code": "FORBIDDEN",
+    "details": {
+      "entityId": "http://example.com/entity/123",
+    },
+    "message": "Access to this resource is restricted",
+  },
+}
+`;

--- a/src/routes/crate.test.ts
+++ b/src/routes/crate.test.ts
@@ -460,6 +460,22 @@ describe('Crate Route Restricted', () => {
     meta: {},
   };
 
+  describe('HEAD /entity/:id', () => {
+    it('should return 403', async () => {
+      prisma.entity.findUnique.mockResolvedValue(mockFileEntity);
+
+      const response = await fastify.inject({
+        method: 'HEAD',
+        url: `/entity/${encodeURIComponent('http://example.com/entity/file.wav')}/rocrate`,
+      });
+      const body = JSON.parse(response.body) as { error: { code: string; message: string } };
+
+      expect(response.statusCode).toBe(403);
+      expect(body.error.code).toBe('FORBIDDEN');
+      expect(mockRoCrateHandler.get).not.toHaveBeenCalled();
+    });
+  });
+
   describe('GET /entity/:id', () => {
     it('should return 403', async () => {
       prisma.entity.findUnique.mockResolvedValue(mockFileEntity);

--- a/src/routes/crate.test.ts
+++ b/src/routes/crate.test.ts
@@ -2,6 +2,7 @@ import { createReadStream } from 'node:fs';
 import { Readable } from 'node:stream';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fastify, fastifyAfter, fastifyBefore, prisma } from '../test/helpers/fastify.js';
+import { AllPublicAccessTransformer } from '../transformers/default.js';
 import type { FileResult, RoCrateHandler } from '../types/fileHandlers.js';
 import type { StandardErrorResponse } from '../utils/errors.js';
 import crateRoute from './crate.js';
@@ -18,7 +19,11 @@ describe('Crate Route', () => {
 
   beforeEach(async () => {
     await fastifyBefore();
-    await fastify.register(crateRoute, { prisma, roCrateHandler: mockRoCrateHandler });
+    await fastify.register(crateRoute, {
+      prisma,
+      accessTransformer: AllPublicAccessTransformer,
+      roCrateHandler: mockRoCrateHandler,
+    });
     vi.clearAllMocks();
   });
 

--- a/src/routes/crate.test.ts
+++ b/src/routes/crate.test.ts
@@ -1,7 +1,7 @@
 import { createReadStream } from 'node:fs';
 import { Readable } from 'node:stream';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { fastify, fastifyAfter, fastifyBefore, prisma } from '../test/helpers/fastify.js';
+import { fastify, fastifyAfter, fastifyBefore, prisma, RestrictedAccessTransformer } from '../test/helpers/fastify.js';
 import { AllPublicAccessTransformer } from '../transformers/default.js';
 import type { FileResult, RoCrateHandler } from '../types/fileHandlers.js';
 import type { StandardErrorResponse } from '../utils/errors.js';
@@ -423,6 +423,56 @@ describe('Crate Route', () => {
 
       expect(response.statusCode).toBe(500);
       expect(body.error.code).toBe('INTERNAL_ERROR');
+    });
+  });
+});
+
+describe('Crate Route Restricted', () => {
+  const mockRoCrateHandler: RoCrateHandler = {
+    get: vi.fn(),
+    head: vi.fn(),
+  };
+
+  beforeEach(async () => {
+    await fastifyBefore();
+    await fastify.register(crateRoute, {
+      prisma,
+      accessTransformer: RestrictedAccessTransformer,
+      roCrateHandler: mockRoCrateHandler,
+    });
+  });
+
+  afterEach(async () => {
+    await fastifyAfter();
+  });
+
+  const mockFileEntity = {
+    id: 'http://example.com/entity/file.wav',
+    name: 'test.wav',
+    description: 'A test file',
+    entityType: 'http://schema.org/MediaObject',
+    memberOf: 'http://example.com/collection',
+    rootCollection: 'http://example.com/collection',
+    metadataLicenseId: 'https://creativecommons.org/licenses/by/4.0/',
+    contentLicenseId: 'https://creativecommons.org/licenses/by/4.0/',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    meta: {},
+  };
+
+  describe('GET /entity/:id', () => {
+    it('should return 403', async () => {
+      prisma.entity.findUnique.mockResolvedValue(mockFileEntity);
+
+      const response = await fastify.inject({
+        method: 'GET',
+        url: `/entity/${encodeURIComponent('http://example.com/entity/file.wav')}/rocrate`,
+      });
+      const body = JSON.parse(response.body) as { error: { code: string; message: string } };
+
+      expect(response.statusCode).toBe(403);
+      expect(body.error.code).toBe('FORBIDDEN');
+      expect(mockRoCrateHandler.get).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/routes/crate.ts
+++ b/src/routes/crate.ts
@@ -45,10 +45,11 @@ const crate: FastifyPluginAsync<CrateRouteOptions> = async (fastify, opts) => {
           rootCollection: { id: entity.rootCollection || '', name: '' },
         };
         const authorisedEntity = await accessTransformer(standardEntity, { request, fastify });
-        if (!authorisedEntity.access.metadata) return createForbiddenError('Access to this resource is restricted');
+        if (!authorisedEntity.access.metadata) {
+          return reply.code(403).send(createForbiddenError('Access to this resource is restricted'));
+        }
 
         const metadata: FileMetadata | false = await roCrateHandler.head(entity, { request, fastify });
-
         if (!metadata) {
           return reply.code(404).send(createNotFoundError('The requested RO-Crate metadata was not found', id));
         }
@@ -90,7 +91,8 @@ const crate: FastifyPluginAsync<CrateRouteOptions> = async (fastify, opts) => {
           rootCollection: { id: entity.rootCollection || '', name: '' },
         };
         const authorisedEntity = await accessTransformer(standardEntity, { request, fastify });
-        if (!authorisedEntity.access.metadata) return createForbiddenError('Access to this resource is restricted');
+        if (!authorisedEntity.access.metadata)
+          return reply.code(403).send(createForbiddenError('Access to this resource is restricted'));
 
         const result = await roCrateHandler.get(entity, { request, fastify });
 

--- a/src/routes/crate.ts
+++ b/src/routes/crate.ts
@@ -4,6 +4,7 @@ import type { ZodTypeProvider } from 'fastify-type-provider-zod';
 import { z } from 'zod/v4';
 import type { PrismaClient } from '../generated/prisma/client.js';
 import type { FileMetadata, RoCrateHandler } from '../types/fileHandlers.js';
+import type { AccessTransformer } from '../types/transformers.js';
 import { createInternalError, createNotFoundError } from '../utils/errors.js';
 import { setFileHeaders } from '../utils/headers.js';
 
@@ -13,11 +14,12 @@ const paramsSchema = z.object({
 
 type CrateRouteOptions = {
   prisma: PrismaClient;
+  accessTransformer: AccessTransformer;
   roCrateHandler: RoCrateHandler;
 };
 
 const crate: FastifyPluginAsync<CrateRouteOptions> = async (fastify, opts) => {
-  const { prisma, roCrateHandler } = opts;
+  const { prisma, accessTransformer, roCrateHandler } = opts;
 
   fastify.withTypeProvider<ZodTypeProvider>().head(
     '/entity/:id/rocrate',
@@ -37,6 +39,13 @@ const crate: FastifyPluginAsync<CrateRouteOptions> = async (fastify, opts) => {
         if (!entity) {
           return reply.code(404).send(createNotFoundError('The requested entity was not found', id));
         }
+        const standardEntity = {
+          ...entity,
+          memberOf: { id: entity.memberOf || '', name: '' },
+          rootCollection: { id: entity.rootCollection || '', name: '' },
+        };
+        const authorisedEntity = await accessTransformer(standardEntity, { request, fastify });
+        if (!authorisedEntity.access.metadata) return reply.forbidden('Access to this resource is restricted');
 
         const metadata: FileMetadata | false = await roCrateHandler.head(entity, { request, fastify });
 
@@ -74,6 +83,14 @@ const crate: FastifyPluginAsync<CrateRouteOptions> = async (fastify, opts) => {
         if (!entity) {
           return reply.code(404).send(createNotFoundError('The requested entity was not found', id));
         }
+
+        const standardEntity = {
+          ...entity,
+          memberOf: { id: entity.memberOf || '', name: '' },
+          rootCollection: { id: entity.rootCollection || '', name: '' },
+        };
+        const authorisedEntity = await accessTransformer(standardEntity, { request, fastify });
+        if (!authorisedEntity.access.metadata) return reply.forbidden('Access to this resource is restricted');
 
         const result = await roCrateHandler.get(entity, { request, fastify });
 

--- a/src/routes/crate.ts
+++ b/src/routes/crate.ts
@@ -5,7 +5,7 @@ import { z } from 'zod/v4';
 import type { PrismaClient } from '../generated/prisma/client.js';
 import type { FileMetadata, RoCrateHandler } from '../types/fileHandlers.js';
 import type { AccessTransformer } from '../types/transformers.js';
-import { createInternalError, createNotFoundError } from '../utils/errors.js';
+import { createForbiddenError, createInternalError, createNotFoundError } from '../utils/errors.js';
 import { setFileHeaders } from '../utils/headers.js';
 
 const paramsSchema = z.object({
@@ -45,7 +45,7 @@ const crate: FastifyPluginAsync<CrateRouteOptions> = async (fastify, opts) => {
           rootCollection: { id: entity.rootCollection || '', name: '' },
         };
         const authorisedEntity = await accessTransformer(standardEntity, { request, fastify });
-        if (!authorisedEntity.access.metadata) return reply.forbidden('Access to this resource is restricted');
+        if (!authorisedEntity.access.metadata) return createForbiddenError('Access to this resource is restricted');
 
         const metadata: FileMetadata | false = await roCrateHandler.head(entity, { request, fastify });
 
@@ -90,7 +90,7 @@ const crate: FastifyPluginAsync<CrateRouteOptions> = async (fastify, opts) => {
           rootCollection: { id: entity.rootCollection || '', name: '' },
         };
         const authorisedEntity = await accessTransformer(standardEntity, { request, fastify });
-        if (!authorisedEntity.access.metadata) return reply.forbidden('Access to this resource is restricted');
+        if (!authorisedEntity.access.metadata) return createForbiddenError('Access to this resource is restricted');
 
         const result = await roCrateHandler.get(entity, { request, fastify });
 

--- a/src/routes/entities.test.ts
+++ b/src/routes/entities.test.ts
@@ -320,14 +320,16 @@ describe('Entities Route', () => {
 });
 
 describe('Entities Route with License Filtering', () => {
+  let hasLicense = true;
   async function resolveValidLicenses() {
-    return ['https://creativecommons.org/licenses/by/4.0/'];
+    if (hasLicense) return ['https://creativecommons.org/licenses/by/4.0/'];
   }
   beforeEach(async () => {
     await fastifyBefore();
     await fastify.register(entitiesRoute, {
       prisma,
       accessTransformer: AllPublicAccessTransformer,
+      // @ts-expect-error
       resolveValidLicenses,
     });
   });
@@ -340,7 +342,7 @@ describe('Entities Route with License Filtering', () => {
     it('should filter by metadataLicenseId', async () => {
       prisma.entity.findMany.mockResolvedValue([]);
       prisma.entity.count.mockResolvedValue(0);
-
+      hasLicense = true;
       const response = await fastify.inject({
         method: 'GET',
         url: '/entities',
@@ -349,6 +351,24 @@ describe('Entities Route with License Filtering', () => {
       expect(response.statusCode).toBe(200);
       expect(prisma.entity.findMany).toHaveBeenCalledWith({
         where: { metadataLicenseId: { in: await resolveValidLicenses() } },
+        include: { file: { select: { id: true } } },
+        orderBy: { id: 'asc' },
+        skip: 0,
+        take: 100,
+      });
+    });
+    it('should return nothing without any valid license', async () => {
+      prisma.entity.findMany.mockResolvedValue([]);
+      prisma.entity.count.mockResolvedValue(0);
+      hasLicense = false;
+      const response = await fastify.inject({
+        method: 'GET',
+        url: '/entities',
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(prisma.entity.findMany).toHaveBeenCalledWith({
+        where: { metadataLicenseId: { in: [] } },
         include: { file: { select: { id: true } } },
         orderBy: { id: 'asc' },
         skip: 0,

--- a/src/routes/entities.test.ts
+++ b/src/routes/entities.test.ts
@@ -318,3 +318,42 @@ describe('Entities Route', () => {
     });
   });
 });
+
+describe('Entities Route with License Filtering', () => {
+  async function resolveValidLicenses() {
+    return ['https://creativecommons.org/licenses/by/4.0/'];
+  }
+  beforeEach(async () => {
+    await fastifyBefore();
+    await fastify.register(entitiesRoute, {
+      prisma,
+      accessTransformer: AllPublicAccessTransformer,
+      resolveValidLicenses,
+    });
+  });
+
+  afterEach(async () => {
+    await fastifyAfter();
+  });
+
+  describe('GET /entities', () => {
+    it('should filter by metadataLicenseId', async () => {
+      prisma.entity.findMany.mockResolvedValue([]);
+      prisma.entity.count.mockResolvedValue(0);
+
+      const response = await fastify.inject({
+        method: 'GET',
+        url: '/entities',
+      });
+
+      expect(response.statusCode).toBe(200);
+      expect(prisma.entity.findMany).toHaveBeenCalledWith({
+        where: { metadataLicenseId: { in: await resolveValidLicenses() } },
+        include: { file: { select: { id: true } } },
+        orderBy: { id: 'asc' },
+        skip: 0,
+        take: 100,
+      });
+    });
+  });
+});

--- a/src/routes/entities.ts
+++ b/src/routes/entities.ts
@@ -3,7 +3,7 @@ import type { ZodTypeProvider } from 'fastify-type-provider-zod';
 import { z } from 'zod/v4';
 import type { PrismaClient } from '../generated/prisma/client.js';
 import { baseEntityTransformer, resolveEntityReferences } from '../transformers/default.js';
-import type { AccessTransformer, EntityTransformer } from '../types/transformers.js';
+import type { AccessTransformer, EntityTransformer, TransformerContext } from '../types/transformers.js';
 import { createInternalError } from '../utils/errors.js';
 
 const querySchema = z.object({
@@ -27,10 +27,11 @@ type EntitiesRouteOptions = {
   prisma: PrismaClient;
   accessTransformer: AccessTransformer;
   entityTransformers?: EntityTransformer[];
+  resolveValidLicenses?: (opt: TransformerContext) => Promise<string[]>;
 };
 
 const entities: FastifyPluginAsync<EntitiesRouteOptions> = async (fastify, opts) => {
-  const { prisma, accessTransformer, entityTransformers = [] } = opts;
+  const { prisma, accessTransformer, entityTransformers = [], resolveValidLicenses } = opts;
   fastify.withTypeProvider<ZodTypeProvider>().get(
     '/entities',
     {
@@ -52,6 +53,15 @@ const entities: FastifyPluginAsync<EntitiesRouteOptions> = async (fastify, opts)
           where.entityType = {
             in: entityType,
           };
+        }
+
+        if (resolveValidLicenses) {
+          const validLicenses = await resolveValidLicenses({ request, fastify });
+          if (validLicenses?.length) {
+            where.metadataLicenseId = {
+              in: validLicenses,
+            };
+          }
         }
 
         const [dbEntities, total] = await Promise.all([

--- a/src/routes/entities.ts
+++ b/src/routes/entities.ts
@@ -56,12 +56,9 @@ const entities: FastifyPluginAsync<EntitiesRouteOptions> = async (fastify, opts)
         }
 
         if (resolveValidLicenses) {
-          const validLicenses = await resolveValidLicenses({ request, fastify });
-          if (validLicenses?.length) {
-            where.metadataLicenseId = {
-              in: validLicenses,
-            };
-          }
+          where.metadataLicenseId = {
+            in: (await resolveValidLicenses({ request, fastify })) || [],
+          };
         }
 
         const [dbEntities, total] = await Promise.all([

--- a/src/routes/entity.test.ts
+++ b/src/routes/entity.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { fastify, fastifyAfter, fastifyBefore, prisma } from '../test/helpers/fastify.js';
+import { fastify, fastifyAfter, fastifyBefore, prisma, RestrictedAccessTransformer } from '../test/helpers/fastify.js';
 import { AllPublicAccessTransformer } from '../transformers/default.js';
 import type { StandardErrorResponse } from '../utils/errors.js';
 import entityRoute from './entity.js';
@@ -154,6 +154,46 @@ describe('Entity Route', () => {
       const body = JSON.parse(response.body);
 
       expect(response.statusCode).toBe(200);
+      expect(body).toMatchSnapshot();
+    });
+  });
+});
+
+describe('Entity Route Restricted', () => {
+  beforeEach(async () => {
+    await fastifyBefore();
+    await fastify.register(entityRoute, { prisma, accessTransformer: RestrictedAccessTransformer });
+  });
+
+  afterEach(async () => {
+    await fastifyAfter();
+  });
+
+  describe('GET /entity/:id', () => {
+    it('should return 403', async () => {
+      const mockEntity = {
+        id: 'http://example.com/entity/123',
+        name: 'Test Entity',
+        description: 'A test entity',
+        entityType: 'http://schema.org/Person',
+        memberOf: null,
+        rootCollection: null,
+        metadataLicenseId: 'https://choosealicense.com/no-permission/',
+        contentLicenseId: 'https://choosealicense.com/no-permission/',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        meta: {},
+      };
+
+      prisma.entity.findUnique.mockResolvedValue(mockEntity);
+
+      const response = await fastify.inject({
+        method: 'GET',
+        url: `/entity/${encodeURIComponent('http://example.com/entity/123')}`,
+      });
+      const body = JSON.parse(response.body);
+
+      expect(response.statusCode).toBe(403);
       expect(body).toMatchSnapshot();
     });
   });

--- a/src/routes/entity.ts
+++ b/src/routes/entity.ts
@@ -49,6 +49,7 @@ const entity: FastifyPluginAsync<EntityRouteOptions> = async (fastify, opts) => 
         };
         const authorisedEntity = await accessTransformer(standardEntity, { request, fastify });
 
+        if (!authorisedEntity.access.metadata) return reply.forbidden('Access to this resource is restricted');
         let result = authorisedEntity;
         for (const transformer of entityTransformers) {
           result = await transformer(result, { request, fastify });

--- a/src/routes/entity.ts
+++ b/src/routes/entity.ts
@@ -4,7 +4,7 @@ import { z } from 'zod/v4';
 import type { PrismaClient } from '../generated/prisma/client.js';
 import { baseEntityTransformer, resolveEntityReferences } from '../transformers/default.js';
 import type { AccessTransformer, EntityTransformer } from '../types/transformers.js';
-import { createInternalError, createNotFoundError } from '../utils/errors.js';
+import { createForbiddenError, createInternalError, createNotFoundError } from '../utils/errors.js';
 
 const paramsSchema = z.object({
   id: z.url(),
@@ -49,7 +49,8 @@ const entity: FastifyPluginAsync<EntityRouteOptions> = async (fastify, opts) => 
         };
         const authorisedEntity = await accessTransformer(standardEntity, { request, fastify });
 
-        if (!authorisedEntity.access.metadata) return reply.forbidden('Access to this resource is restricted');
+        if (!authorisedEntity.access.metadata)
+          return reply.code(403).send(createForbiddenError('Access to this resource is restricted', id));
         let result = authorisedEntity;
         for (const transformer of entityTransformers) {
           result = await transformer(result, { request, fastify });

--- a/src/routes/file.test.ts
+++ b/src/routes/file.test.ts
@@ -1,7 +1,13 @@
 import { createReadStream } from 'node:fs';
 import { Readable } from 'node:stream';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { fastify, fastifyAfter, fastifyBefore, prisma } from '../test/helpers/fastify.js';
+import {
+  fastify,
+  fastifyAfter,
+  fastifyBefore,
+  prisma,
+  RestrictedFileAccessTransformer,
+} from '../test/helpers/fastify.js';
 import { AllPublicFileAccessTransformer } from '../transformers/default.js';
 import type { FileHandler, FileResult } from '../types/fileHandlers.js';
 import type { StandardErrorResponse } from '../utils/errors.js';
@@ -39,6 +45,9 @@ describe('File Route', () => {
     meta: { storagePath: '/data/files/test.wav' },
     createdAt: new Date(),
     updatedAt: new Date(),
+    entity: {
+      memberOf: null,
+    },
   };
 
   describe('GET /file/:id', () => {
@@ -395,6 +404,79 @@ describe('File Route', () => {
 
       expect(response.statusCode).toBe(500);
       expect(body.error.code).toBe('INTERNAL_ERROR');
+    });
+  });
+});
+
+describe('File Route Restricted', () => {
+  const mockFileHandler: FileHandler = {
+    get: vi.fn(),
+    head: vi.fn(),
+  };
+
+  beforeEach(async () => {
+    await fastifyBefore();
+    await fastify.register(fileRoute, {
+      prisma,
+      fileAccessTransformer: RestrictedFileAccessTransformer,
+      fileHandler: mockFileHandler,
+    });
+    vi.clearAllMocks();
+  });
+
+  afterEach(async () => {
+    await fastifyAfter();
+  });
+
+  const mockFile = {
+    id: 'http://example.com/file/test.wav',
+    filename: 'test.wav',
+    mediaType: 'audio/wav',
+    size: BigInt(1024),
+    meta: { storagePath: '/data/files/test.wav' },
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    entity: {
+      memberOf: null,
+    },
+  };
+
+  describe('HEAD /file/:id', () => {
+    it('should return 403', async () => {
+      prisma.file.findUnique.mockResolvedValue(mockFile);
+      vi.mocked(mockFileHandler.get).mockResolvedValue({
+        type: 'redirect',
+        url: 'https://storage.example.com/files/test.wav',
+      });
+
+      const response = await fastify.inject({
+        method: 'HEAD',
+        url: `/file/${encodeURIComponent('http://example.com/file/test.wav')}`,
+      });
+      const body = (await response.json()) as { error: { code: string; message: string } };
+
+      expect(response.statusCode).toBe(403);
+      expect(body.error.code).toBe('FORBIDDEN');
+      expect(mockFileHandler.get).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('GET /file/:id', () => {
+    it('should return 403', async () => {
+      prisma.file.findUnique.mockResolvedValue(mockFile);
+      vi.mocked(mockFileHandler.get).mockResolvedValue({
+        type: 'redirect',
+        url: 'https://storage.example.com/files/test.wav',
+      });
+
+      const response = await fastify.inject({
+        method: 'GET',
+        url: `/file/${encodeURIComponent('http://example.com/file/test.wav')}`,
+      });
+      const body = (await response.json()) as { error: { code: string; message: string } };
+
+      expect(response.statusCode).toBe(403);
+      expect(body.error.code).toBe('FORBIDDEN');
     });
   });
 });

--- a/src/routes/file.test.ts
+++ b/src/routes/file.test.ts
@@ -2,6 +2,7 @@ import { createReadStream } from 'node:fs';
 import { Readable } from 'node:stream';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { fastify, fastifyAfter, fastifyBefore, prisma } from '../test/helpers/fastify.js';
+import { AllPublicFileAccessTransformer } from '../transformers/default.js';
 import type { FileHandler, FileResult } from '../types/fileHandlers.js';
 import type { StandardErrorResponse } from '../utils/errors.js';
 import fileRoute from './file.js';
@@ -18,7 +19,11 @@ describe('File Route', () => {
 
   beforeEach(async () => {
     await fastifyBefore();
-    await fastify.register(fileRoute, { prisma, fileHandler: mockFileHandler });
+    await fastify.register(fileRoute, {
+      prisma,
+      fileAccessTransformer: AllPublicFileAccessTransformer,
+      fileHandler: mockFileHandler,
+    });
     vi.clearAllMocks();
   });
 

--- a/src/routes/file.ts
+++ b/src/routes/file.ts
@@ -6,7 +6,7 @@ import type { PrismaClient } from '../generated/prisma/client.js';
 import { baseFileTransformer, resolveEntityReferences } from '../transformers/default.js';
 import type { FileHandler, FileMetadata } from '../types/fileHandlers.js';
 import type { FileAccessTransformer } from '../types/transformers.js';
-import { createInternalError, createNotFoundError } from '../utils/errors.js';
+import { createForbiddenError, createInternalError, createNotFoundError } from '../utils/errors.js';
 import { setFileHeaders } from '../utils/headers.js';
 
 const paramsSchema = z.object({
@@ -56,7 +56,9 @@ const file: FastifyPluginAsync<FileRouteOptions> = async (fastify, opts) => {
           rootCollection: file.entity.rootCollection ? (refMap.get(file.entity.rootCollection) ?? null) : null,
         };
         const authorisedFile = await fileAccessTransformer(entity, { request, fastify });
-        if (!authorisedFile.access.content) return reply.forbidden('Access to this resource is restricted');
+        if (!authorisedFile.access.content) {
+          return reply.code(403).send(createForbiddenError('Access to this resource is restricted', id));
+        }
 
         const metadata: FileMetadata | false = await fileHandler.head(file, { request, fastify });
 
@@ -105,7 +107,9 @@ const file: FastifyPluginAsync<FileRouteOptions> = async (fastify, opts) => {
           rootCollection: file.entity.rootCollection ? (refMap.get(file.entity.rootCollection) ?? null) : null,
         };
         const authorisedFile = await fileAccessTransformer(entity, { request, fastify });
-        if (!authorisedFile.access.content) return reply.forbidden('Access to this resource is restricted');
+        if (!authorisedFile.access.content) {
+          return reply.code(403).send(createForbiddenError('Access to this resource is restricted', id));
+        }
 
         const result = await fileHandler.get(file, { request, fastify });
 

--- a/src/routes/file.ts
+++ b/src/routes/file.ts
@@ -3,7 +3,9 @@ import type { FastifyPluginAsync } from 'fastify';
 import type { ZodTypeProvider } from 'fastify-type-provider-zod';
 import { z } from 'zod/v4';
 import type { PrismaClient } from '../generated/prisma/client.js';
+import { baseFileTransformer, resolveEntityReferences } from '../transformers/default.js';
 import type { FileHandler, FileMetadata } from '../types/fileHandlers.js';
+import type { FileAccessTransformer } from '../types/transformers.js';
 import { createInternalError, createNotFoundError } from '../utils/errors.js';
 import { setFileHeaders } from '../utils/headers.js';
 
@@ -19,11 +21,12 @@ const querySchema = z.object({
 
 type FileRouteOptions = {
   prisma: PrismaClient;
+  fileAccessTransformer: FileAccessTransformer;
   fileHandler: FileHandler;
 };
 
 const file: FastifyPluginAsync<FileRouteOptions> = async (fastify, opts) => {
-  const { prisma, fileHandler } = opts;
+  const { prisma, fileAccessTransformer, fileHandler } = opts;
 
   fastify.withTypeProvider<ZodTypeProvider>().head(
     '/file/:id',
@@ -38,11 +41,22 @@ const file: FastifyPluginAsync<FileRouteOptions> = async (fastify, opts) => {
       try {
         const file = await prisma.file.findUnique({
           where: { id },
+          include: { entity: true },
         });
 
         if (!file) {
           return reply.code(404).send(createNotFoundError('The requested file was not found', id));
         }
+
+        const refMap = await resolveEntityReferences([{ ...file.entity }], prisma);
+        const entity = {
+          ...file.entity,
+          ...baseFileTransformer(file),
+          memberOf: file.entity.memberOf ? (refMap.get(file.entity.memberOf) ?? null) : null,
+          rootCollection: file.entity.rootCollection ? (refMap.get(file.entity.rootCollection) ?? null) : null,
+        };
+        const authorisedFile = await fileAccessTransformer(entity, { request, fastify });
+        if (!authorisedFile.access.content) return reply.forbidden('Access to this resource is restricted');
 
         const metadata: FileMetadata | false = await fileHandler.head(file, { request, fastify });
 
@@ -76,11 +90,22 @@ const file: FastifyPluginAsync<FileRouteOptions> = async (fastify, opts) => {
       try {
         const file = await prisma.file.findUnique({
           where: { id },
+          include: { entity: true },
         });
 
         if (!file) {
           return reply.code(404).send(createNotFoundError('The requested file was not found', id));
         }
+
+        const refMap = await resolveEntityReferences([{ ...file.entity }], prisma);
+        const entity = {
+          ...file.entity,
+          ...baseFileTransformer(file),
+          memberOf: file.entity.memberOf ? (refMap.get(file.entity.memberOf) ?? null) : null,
+          rootCollection: file.entity.rootCollection ? (refMap.get(file.entity.rootCollection) ?? null) : null,
+        };
+        const authorisedFile = await fileAccessTransformer(entity, { request, fastify });
+        if (!authorisedFile.access.content) return reply.forbidden('Access to this resource is restricted');
 
         const result = await fileHandler.get(file, { request, fastify });
 

--- a/src/routes/files.test.ts
+++ b/src/routes/files.test.ts
@@ -284,14 +284,16 @@ describe('Files Route', () => {
 });
 
 describe('Files Route with License Filtering', () => {
+  let hasLicense = true;
   async function resolveValidLicenses() {
-    return ['https://creativecommons.org/licenses/by/4.0/'];
+    if (hasLicense) return ['https://creativecommons.org/licenses/by/4.0/'];
   }
   beforeEach(async () => {
     await fastifyBefore();
     await fastify.register(filesRoute, {
       prisma,
       fileAccessTransformer: AllPublicFileAccessTransformer,
+      // @ts-expect-error
       resolveValidLicenses,
     });
   });
@@ -304,7 +306,7 @@ describe('Files Route with License Filtering', () => {
     it('should filter by metadataLicenseId', async () => {
       prisma.file.findMany.mockResolvedValue([]);
       prisma.file.count.mockResolvedValue(0);
-
+      hasLicense = true;
       const response = await fastify.inject({
         method: 'GET',
         url: '/files',
@@ -313,6 +315,21 @@ describe('Files Route with License Filtering', () => {
       expect(prisma.file.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
           where: { entity: { metadataLicenseId: { in: await resolveValidLicenses() } } },
+        }),
+      );
+    });
+    it('should filter by metadataLicenseId, no license', async () => {
+      prisma.file.findMany.mockResolvedValue([]);
+      prisma.file.count.mockResolvedValue(0);
+      hasLicense = false;
+      const response = await fastify.inject({
+        method: 'GET',
+        url: '/files',
+      });
+      expect(response.statusCode).toBe(200);
+      expect(prisma.file.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { entity: { metadataLicenseId: { in: [] } } },
         }),
       );
     });

--- a/src/routes/files.test.ts
+++ b/src/routes/files.test.ts
@@ -23,6 +23,9 @@ describe('Files Route', () => {
     meta: {},
     createdAt: new Date('2025-01-01'),
     updatedAt: new Date('2025-01-01'),
+    entity: {
+      memberOf: null,
+    },
   };
 
   const mockFile2 = {
@@ -33,6 +36,9 @@ describe('Files Route', () => {
     meta: {},
     createdAt: new Date('2025-01-02'),
     updatedAt: new Date('2025-01-02'),
+    entity: {
+      memberOf: null,
+    },
   };
 
   describe('GET /files', () => {
@@ -273,6 +279,42 @@ describe('Files Route', () => {
       });
 
       await fastifyAfter();
+    });
+  });
+});
+
+describe('Files Route with License Filtering', () => {
+  async function resolveValidLicenses() {
+    return ['https://creativecommons.org/licenses/by/4.0/'];
+  }
+  beforeEach(async () => {
+    await fastifyBefore();
+    await fastify.register(filesRoute, {
+      prisma,
+      fileAccessTransformer: AllPublicFileAccessTransformer,
+      resolveValidLicenses,
+    });
+  });
+
+  afterEach(async () => {
+    await fastifyAfter();
+  });
+
+  describe('GET /files', () => {
+    it('should filter by metadataLicenseId', async () => {
+      prisma.file.findMany.mockResolvedValue([]);
+      prisma.file.count.mockResolvedValue(0);
+
+      const response = await fastify.inject({
+        method: 'GET',
+        url: '/files',
+      });
+      expect(response.statusCode).toBe(200);
+      expect(prisma.file.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { entity: { metadataLicenseId: { in: await resolveValidLicenses() } } },
+        }),
+      );
     });
   });
 });

--- a/src/routes/files.ts
+++ b/src/routes/files.ts
@@ -3,7 +3,7 @@ import type { ZodTypeProvider } from 'fastify-type-provider-zod';
 import { z } from 'zod/v4';
 import type { PrismaClient } from '../generated/prisma/client.js';
 import { baseFileTransformer, resolveEntityReferences } from '../transformers/default.js';
-import type { FileAccessTransformer, FileTransformer } from '../types/transformers.js';
+import type { FileAccessTransformer, FileTransformer, TransformerContext } from '../types/transformers.js';
 import { createInternalError } from '../utils/errors.js';
 
 const querySchema = z.object({
@@ -18,10 +18,11 @@ type FilesRouteOptions = {
   prisma: PrismaClient;
   fileAccessTransformer: FileAccessTransformer;
   fileTransformers?: FileTransformer[];
+  resolveValidLicenses?: (opt: TransformerContext) => Promise<string[]>;
 };
 
 const files: FastifyPluginAsync<FilesRouteOptions> = async (fastify, opts) => {
-  const { prisma, fileAccessTransformer, fileTransformers = [] } = opts;
+  const { prisma, fileAccessTransformer, fileTransformers, resolveValidLicenses } = opts;
 
   fastify.withTypeProvider<ZodTypeProvider>().get(
     '/files',
@@ -38,6 +39,16 @@ const files: FastifyPluginAsync<FilesRouteOptions> = async (fastify, opts) => {
 
         if (memberOf) {
           where.entity = { memberOf };
+        }
+
+        if (resolveValidLicenses) {
+          const validLicenses = await resolveValidLicenses({ request, fastify });
+          if (validLicenses?.length) {
+            where.entity = where.entity || {};
+            where.entity.metadataLicenseId = {
+              in: validLicenses,
+            };
+          }
         }
 
         const [dbFiles, total] = await Promise.all([
@@ -69,7 +80,7 @@ const files: FastifyPluginAsync<FilesRouteOptions> = async (fastify, opts) => {
             const authorisedFile = await fileAccessTransformer(entity, { request, fastify });
 
             let result = authorisedFile;
-            for (const transformer of fileTransformers) {
+            for (const transformer of fileTransformers || []) {
               result = await transformer(result, { request, fastify });
             }
 

--- a/src/routes/files.ts
+++ b/src/routes/files.ts
@@ -42,13 +42,10 @@ const files: FastifyPluginAsync<FilesRouteOptions> = async (fastify, opts) => {
         }
 
         if (resolveValidLicenses) {
-          const validLicenses = await resolveValidLicenses({ request, fastify });
-          if (validLicenses?.length) {
-            where.entity = where.entity || {};
-            where.entity.metadataLicenseId = {
-              in: validLicenses,
-            };
-          }
+          where.entity = where.entity || {};
+          where.entity.metadataLicenseId = {
+            in: (await resolveValidLicenses({ request, fastify })) || [],
+          };
         }
 
         const [dbFiles, total] = await Promise.all([

--- a/src/routes/files.ts
+++ b/src/routes/files.ts
@@ -2,7 +2,7 @@ import type { FastifyPluginAsync } from 'fastify';
 import type { ZodTypeProvider } from 'fastify-type-provider-zod';
 import { z } from 'zod/v4';
 import type { PrismaClient } from '../generated/prisma/client.js';
-import { baseFileTransformer } from '../transformers/default.js';
+import { baseFileTransformer, resolveEntityReferences } from '../transformers/default.js';
 import type { FileAccessTransformer, FileTransformer } from '../types/transformers.js';
 import { createInternalError } from '../utils/errors.js';
 
@@ -48,15 +48,25 @@ const files: FastifyPluginAsync<FilesRouteOptions> = async (fastify, opts) => {
             },
             skip: offset,
             take: limit,
+            include: { entity: true },
           }),
           prisma.file.count({ where }),
         ]);
 
+        const refMap = await resolveEntityReferences(
+          dbFiles.map((f) => f.entity),
+          prisma,
+        );
         // Apply transformers to each entity: base -> access -> additional
         const filesWithAccess = await Promise.all(
           dbFiles.map(async (dbFile) => {
-            const standardFile = baseFileTransformer(dbFile);
-            const authorisedFile = await fileAccessTransformer(standardFile, { request, fastify });
+            const entity = {
+              ...dbFile.entity,
+              ...baseFileTransformer(dbFile),
+              memberOf: dbFile.entity.memberOf ? (refMap.get(dbFile.entity.memberOf) ?? null) : null,
+              rootCollection: dbFile.entity.rootCollection ? (refMap.get(dbFile.entity.rootCollection) ?? null) : null,
+            };
+            const authorisedFile = await fileAccessTransformer(entity, { request, fastify });
 
             let result = authorisedFile;
             for (const transformer of fileTransformers) {

--- a/src/routes/search.test.ts
+++ b/src/routes/search.test.ts
@@ -903,8 +903,9 @@ describe('Search Route', () => {
 });
 
 describe('Search Route with License Filtering', () => {
+  let hasLicense = true;
   async function resolveValidLicenses() {
-    return ['https://creativecommons.org/licenses/by/4.0/'];
+    if (hasLicense) return ['https://creativecommons.org/licenses/by/4.0/'];
   }
   beforeEach(async () => {
     await fastifyBefore();
@@ -912,6 +913,7 @@ describe('Search Route with License Filtering', () => {
       prisma,
       opensearch,
       accessTransformer: AllPublicAccessTransformer,
+      // @ts-expect-error
       resolveValidLicenses,
     });
   });
@@ -921,73 +923,77 @@ describe('Search Route with License Filtering', () => {
   });
 
   describe('POST /search', () => {
-    it('should filter by metadataLicenseId', async () => {
-      const mockSearchResponse = {
-        body: {
-          took: 5,
-          hits: {
-            total: { value: 0 },
-            hits: [],
+    function testMockLicense(hasLicense_: boolean) {
+      hasLicense = hasLicense_;
+      return async () => {
+        const mockSearchResponse = {
+          body: {
+            took: 5,
+            hits: {
+              total: { value: 0 },
+              hits: [],
+            },
+            aggregations: {},
           },
-          aggregations: {},
-        },
+        };
+
+        // @ts-expect-error TS is looking at the wrong function signature
+        opensearch.search.mockResolvedValue(mockSearchResponse);
+        prisma.entity.findMany.mockResolvedValue([]);
+        const response = await fastify.inject({
+          method: 'POST',
+          url: '/search',
+          payload: {
+            query: 'test',
+            searchType: 'basic',
+          },
+        });
+        expect(response.statusCode).toBe(200);
+        expect(opensearch.search).toHaveBeenCalledWith({
+          index: 'entities',
+          body: {
+            query: {
+              bool: {
+                must: [
+                  {
+                    multi_match: {
+                      fields: ['name^2', 'description'],
+                      fuzziness: 'AUTO',
+                      query: 'test',
+                      type: 'best_fields',
+                      zero_terms_query: 'all',
+                    },
+                  },
+                ],
+                filter: [
+                  {
+                    terms: {
+                      metadataLicenseId: hasLicense ? await resolveValidLicenses() : [],
+                    },
+                  },
+                ],
+              },
+            },
+            aggs: {
+              inLanguage: { terms: { field: 'inLanguage.keyword', size: 20 } },
+              mediaType: { terms: { field: 'mediaType.keyword', size: 20 } },
+              communicationMode: { terms: { field: 'communicationMode.keyword', size: 20 } },
+              entityType: { terms: { field: 'entityType.keyword', size: 20 } },
+            },
+            highlight: {
+              fields: {
+                name: {},
+                description: {},
+              },
+            },
+            sort: undefined,
+            from: 0,
+            size: 100,
+          },
+        });
       };
-
-      // @ts-expect-error TS is looking at the wrong function signature
-      opensearch.search.mockResolvedValue(mockSearchResponse);
-      prisma.entity.findMany.mockResolvedValue([]);
-
-      const response = await fastify.inject({
-        method: 'POST',
-        url: '/search',
-        payload: {
-          query: 'test',
-          searchType: 'basic',
-        },
-      });
-      expect(response.statusCode).toBe(200);
-      expect(opensearch.search).toHaveBeenCalledWith({
-        index: 'entities',
-        body: {
-          query: {
-            bool: {
-              must: [
-                {
-                  multi_match: {
-                    fields: ['name^2', 'description'],
-                    fuzziness: 'AUTO',
-                    query: 'test',
-                    type: 'best_fields',
-                    zero_terms_query: 'all',
-                  },
-                },
-              ],
-              filter: [
-                {
-                  terms: {
-                    metadataLicenseId: await resolveValidLicenses(),
-                  },
-                },
-              ],
-            },
-          },
-          aggs: {
-            inLanguage: { terms: { field: 'inLanguage.keyword', size: 20 } },
-            mediaType: { terms: { field: 'mediaType.keyword', size: 20 } },
-            communicationMode: { terms: { field: 'communicationMode.keyword', size: 20 } },
-            entityType: { terms: { field: 'entityType.keyword', size: 20 } },
-          },
-          highlight: {
-            fields: {
-              name: {},
-              description: {},
-            },
-          },
-          sort: undefined,
-          from: 0,
-          size: 100,
-        },
-      });
-    });
+    }
+    it('should filter by metadataLicenseId', testMockLicense(true));
+    it('should return nothing without any valid license', testMockLicense(false));
   });
 });

--- a/src/routes/search.test.ts
+++ b/src/routes/search.test.ts
@@ -901,3 +901,93 @@ describe('Search Route', () => {
     });
   });
 });
+
+describe('Search Route with License Filtering', () => {
+  async function resolveValidLicenses() {
+    return ['https://creativecommons.org/licenses/by/4.0/'];
+  }
+  beforeEach(async () => {
+    await fastifyBefore();
+    await fastify.register(searchRoute, {
+      prisma,
+      opensearch,
+      accessTransformer: AllPublicAccessTransformer,
+      resolveValidLicenses,
+    });
+  });
+
+  afterEach(async () => {
+    await fastifyAfter();
+  });
+
+  describe('POST /search', () => {
+    it('should filter by metadataLicenseId', async () => {
+      const mockSearchResponse = {
+        body: {
+          took: 5,
+          hits: {
+            total: { value: 0 },
+            hits: [],
+          },
+          aggregations: {},
+        },
+      };
+
+      // @ts-expect-error TS is looking at the wrong function signature
+      opensearch.search.mockResolvedValue(mockSearchResponse);
+      prisma.entity.findMany.mockResolvedValue([]);
+
+      const response = await fastify.inject({
+        method: 'POST',
+        url: '/search',
+        payload: {
+          query: 'test',
+          searchType: 'basic',
+        },
+      });
+      expect(response.statusCode).toBe(200);
+      expect(opensearch.search).toHaveBeenCalledWith({
+        index: 'entities',
+        body: {
+          query: {
+            bool: {
+              must: [
+                {
+                  multi_match: {
+                    fields: ['name^2', 'description'],
+                    fuzziness: 'AUTO',
+                    query: 'test',
+                    type: 'best_fields',
+                    zero_terms_query: 'all',
+                  },
+                },
+              ],
+              filter: [
+                {
+                  terms: {
+                    metadataLicenseId: await resolveValidLicenses(),
+                  },
+                },
+              ],
+            },
+          },
+          aggs: {
+            inLanguage: { terms: { field: 'inLanguage.keyword', size: 20 } },
+            mediaType: { terms: { field: 'mediaType.keyword', size: 20 } },
+            communicationMode: { terms: { field: 'communicationMode.keyword', size: 20 } },
+            entityType: { terms: { field: 'entityType.keyword', size: 20 } },
+          },
+          highlight: {
+            fields: {
+              name: {},
+              description: {},
+            },
+          },
+          sort: undefined,
+          from: 0,
+          size: 100,
+        },
+      });
+    });
+  });
+});

--- a/src/routes/search.ts
+++ b/src/routes/search.ts
@@ -65,11 +65,8 @@ const search: FastifyPluginAsync<SearchRouteOptions> = async (fastify, opts) => 
       const { searchType, query, boundingBox, geohashPrecision, limit, offset, sort, order } = request.body;
       let filters = request.body.filters;
       if (resolveValidLicenses) {
-        const validLicenses = await resolveValidLicenses({ request, fastify });
-        if (validLicenses?.length) {
-          filters = filters || {};
-          filters.metadataLicenseId = validLicenses;
-        }
+        filters = filters || {};
+        filters.metadataLicenseId = (await resolveValidLicenses({ request, fastify })) || [];
       }
       try {
         const opensearchQuery: Search_Request = {

--- a/src/routes/search.ts
+++ b/src/routes/search.ts
@@ -6,7 +6,7 @@ import type { ZodTypeProvider } from 'fastify-type-provider-zod';
 import { z } from 'zod/v4';
 import type { PrismaClient } from '../generated/prisma/client.js';
 import { baseEntityTransformer, resolveEntityReferences } from '../transformers/default.js';
-import type { AccessTransformer, EntityTransformer } from '../types/transformers.js';
+import type { AccessTransformer, EntityTransformer, TransformerContext } from '../types/transformers.js';
 import { createInternalError, createInvalidRequestError } from '../utils/errors.js';
 import { OpensearchQueryBuilder, type QueryBuilderOptions } from '../utils/queryBuilder.js';
 
@@ -38,6 +38,7 @@ type SearchRouteOptions = {
   opensearch: Client;
   accessTransformer: AccessTransformer;
   entityTransformers?: EntityTransformer[];
+  resolveValidLicenses?: (opt: TransformerContext) => Promise<string[]>;
   queryBuilderClass?: typeof OpensearchQueryBuilder;
   queryBuilderOptions?: QueryBuilderOptions;
 };
@@ -48,6 +49,7 @@ const search: FastifyPluginAsync<SearchRouteOptions> = async (fastify, opts) => 
     opensearch,
     accessTransformer,
     entityTransformers = [],
+    resolveValidLicenses,
     queryBuilderClass = OpensearchQueryBuilder,
     queryBuilderOptions,
   } = opts;
@@ -60,8 +62,15 @@ const search: FastifyPluginAsync<SearchRouteOptions> = async (fastify, opts) => 
       },
     },
     async (request, reply) => {
-      const { searchType, query, filters, boundingBox, geohashPrecision, limit, offset, sort, order } = request.body;
-
+      const { searchType, query, boundingBox, geohashPrecision, limit, offset, sort, order } = request.body;
+      let filters = request.body.filters;
+      if (resolveValidLicenses) {
+        const validLicenses = await resolveValidLicenses({ request, fastify });
+        if (validLicenses?.length) {
+          filters = filters || {};
+          filters.metadataLicenseId = validLicenses;
+        }
+      }
       try {
         const opensearchQuery: Search_Request = {
           index: 'entities',

--- a/src/test/helpers/fastify.ts
+++ b/src/test/helpers/fastify.ts
@@ -5,6 +5,7 @@ import { serializerCompiler, validatorCompiler } from 'fastify-type-provider-zod
 import { mockDeep, mockReset } from 'vitest-mock-extended';
 
 import type { PrismaClient } from '../../generated/prisma/client.js';
+import type { AccessTransformer, FileAccessTransformer } from '../../types/transformers.js';
 
 export let fastify: FastifyInstance;
 export const prisma = mockDeep<PrismaClient>();
@@ -25,3 +26,23 @@ export const fastifyBefore = async () => {
 export const fastifyAfter = async () => {
   await fastify.close();
 };
+
+export const RestrictedAccessTransformer: AccessTransformer = (entity) => ({
+  ...entity,
+  access: {
+    metadata: false,
+    content: false,
+    metadataAuthorizationUrl: '',
+    contentAuthorizationUrl: '',
+  },
+});
+
+export const RestrictedFileAccessTransformer: FileAccessTransformer = (file) => ({
+  ...file,
+  access: {
+    metadata: false,
+    content: false,
+    metadataAuthorizationUrl: '',
+    contentAuthorizationUrl: '',
+  },
+});

--- a/src/transformers/default.ts
+++ b/src/transformers/default.ts
@@ -78,12 +78,14 @@ export type StandardFile = {
   size: number;
 };
 
+export type FileEntity = StandardFile & StandardEntity;
+
 /**
  * Authorised file - includes access information
  * This is the output of the file access transformer
  * File metadata is always accessible - only content access is controlled
  */
-export type AuthorisedFile = StandardFile & {
+export type AuthorisedFile = FileEntity & {
   access: FileAccessInfo;
 };
 
@@ -166,7 +168,7 @@ export const baseFileTransformer = (file: File): StandardFile => ({
  * });
  * ```
  */
-export const AllPublicFileAccessTransformer = (file: StandardFile): AuthorisedFile => ({
+export const AllPublicFileAccessTransformer = (file: FileEntity): AuthorisedFile => ({
   ...file,
   access: {
     content: true,

--- a/src/types/transformers.ts
+++ b/src/types/transformers.ts
@@ -1,5 +1,5 @@
 import type { FastifyInstance, FastifyRequest } from 'fastify';
-import type { AuthorisedEntity, AuthorisedFile, StandardEntity, StandardFile } from '../transformers/default.js';
+import type { AuthorisedEntity, AuthorisedFile, FileEntity, StandardEntity } from '../transformers/default.js';
 
 /**
  * Context provided to entity transformers
@@ -36,7 +36,7 @@ export type EntityTransformer<TInput = AuthorisedEntity, TOutput = TInput> = (
  * Only content access is controlled (access.content)
  */
 export type FileAccessTransformer = (
-  file: StandardFile,
+  file: FileEntity,
   context: TransformerContext,
 ) => Promise<AuthorisedFile> | AuthorisedFile;
 

--- a/src/utils/errors.test.ts
+++ b/src/utils/errors.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createInternalError, createNotFoundError } from './errors.js';
+import { createForbiddenError, createInternalError, createNotFoundError } from './errors.js';
 
 describe('Error Utilities', () => {
   describe('createInternalError', () => {
@@ -66,6 +66,21 @@ describe('Error Utilities', () => {
       expect(error).toEqual({
         error: {
           code: 'NOT_FOUND',
+          message,
+          details: undefined,
+        },
+      });
+    });
+  });
+
+  describe('createForbiddenError', () => {
+    it('should create a forbidden error', () => {
+      const message = 'Access to this resource is restricted';
+      const error = createForbiddenError(message);
+
+      expect(error).toEqual({
+        error: {
+          code: 'FORBIDDEN',
           message,
           details: undefined,
         },

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -5,6 +5,7 @@ const ERROR_CODES = {
   INTERNAL_ERROR: 'INTERNAL_ERROR',
   INVALID_REQUEST: 'INVALID_REQUEST',
   INVALID_ENTITY_TYPE: 'INVALID_ENTITY_TYPE',
+  FORBIDDEN: 'FORBIDDEN',
 } as const;
 
 type ErrorCode = (typeof ERROR_CODES)[keyof typeof ERROR_CODES];
@@ -47,3 +48,6 @@ export const createInvalidRequestError = (message: string): StandardErrorRespons
 export const createInternalError = (message = 'Internal server error'): StandardErrorResponse => {
   return createErrorResponse(ERROR_CODES.INTERNAL_ERROR, message);
 };
+
+export const createForbiddenError = (message: string, entityId?: string): StandardErrorResponse =>
+  createErrorResponse(ERROR_CODES.FORBIDDEN, message, entityId ? { entityId } : undefined);


### PR DESCRIPTION
Added access restriction functionality based on the:
1. For endpoints `/crate`, `/entity`, `/file`: responds with 403 when `access.metadata` returned by accessTransformer function is false.
2. For endpoints `/search`, `/entities`, `/files`: Use the resolveValidLicenses helper function (if it is specified in the options) to retrieve a list of valid licenses granted to the logged-in user and use the list to filter the search query.